### PR TITLE
Fix regression in S102 v3.0 grid origin calculation

### DIFF
--- a/s100py/s102/v3_0/api.py
+++ b/s100py/s102/v3_0/api.py
@@ -2266,7 +2266,8 @@ class S102File(S100File):
             raise S102Exception("raster is not north up but is rotated, this is not handled at this time")
 
         if "origin" not in metadata:
-            metadata["origin"] = [ulx, uly]
+            # shift the gdal geotransform corner point to reference the node (pixel is center) rather than cell (pixel is area)
+            metadata["origin"] = [ulx + dxx / 2, uly + dyy / 2]
         if "res" not in metadata:
             metadata["res"] = [dxx, dyy]
         if dataset.RasterCount > 2:


### PR DESCRIPTION
The half-pixel offset adjustment was removed in v3.0, causing GDAL raster imports to have grid origins referencing cell corners instead of cell centers. This seems to violate the S102 v3.0 requirement for `data_offset_code=5` (barycentric). Restored the adjustment present in v2.0/v2.1/v2.2.

Was this change intentional? Please let me know if there's context I'm missing.